### PR TITLE
Minetweaker for Grinder

### DIFF
--- a/Auxiliary/RecipeManagers/RecipesGrinder.java
+++ b/Auxiliary/RecipeManagers/RecipesGrinder.java
@@ -35,6 +35,7 @@ public class RecipesGrinder {
 	public static final int ore_rate = 3;
 
 	private final ItemHashMap<ItemStack> recipes = new ItemHashMap().setOneWay();
+	private final ItemHashMap<ItemStack> extraRecipes = new ItemHashMap();
 
 	public static final RecipesGrinder getRecipes()
 	{
@@ -128,12 +129,19 @@ public class RecipesGrinder {
 	}
 
 	public boolean isProduct(ItemStack item) {
-		return ReikaItemHelper.collectionContainsItemStack(recipes.values(), item);
+		return ReikaItemHelper.collectionContainsItemStack(recipes.values(), item) || ReikaItemHelper.collectionContainsItemStack(extraRecipes.values(), item);
 	}
 
 	public List<ItemStack> getSources(ItemStack out) {
 		List<ItemStack> in = new ArrayList();
 		for (ItemStack input : recipes.keySet()) {
+			ItemStack is = this.getGrindingResult(input);
+			if (is != null) {
+				if (ReikaItemHelper.matchStacks(is, out))
+					in.add(input.copy());
+			}
+		}
+		for (ItemStack input : extraRecipes.keySet()) {
 			ItemStack is = this.getGrindingResult(input);
 			if (is != null) {
 				if (ReikaItemHelper.matchStacks(is, out))
@@ -164,11 +172,20 @@ public class RecipesGrinder {
 		//this.ExtractorExperience.put(Integer.valueOf(itemStack), Float.valueOf(xp));
 	}
 
+	public void addExtraRecipe(ItemStack in, ItemStack out) {
+		extraRecipes.put(in, out);
+	}
+	
+	public void removeExtraRecipe(ItemStack in) {
+		extraRecipes.remove(in);
+	}
+	
 	public ItemStack getGrindingResult(ItemStack item) {
 		if (item == null)
 			return null;
 		//ModLoader.getMinecraftInstance().ingameGUI.addChatMessage(String.format("%d  %d", Items, item.getItemDamage()));
 		ItemStack ret = recipes.get(item);
+		if (ret == null) ret = extraRecipes.get(item);
 		return ret != null ? ret.copy() : null;
 	}
 

--- a/ModInterface/Minetweaker/GrinderTweaker.java
+++ b/ModInterface/Minetweaker/GrinderTweaker.java
@@ -1,0 +1,133 @@
+package RotaryCraft.ModInterface.Minetweaker;
+
+import Reika.RotaryCraft.Auxiliary.RecipeManagers.RecipesGrinder;
+import Reika.RotaryCraft.TileEntities.Processing.TileEntityGrinder;
+import minetweaker.IUndoableAction;
+import minetweaker.MineTweakerAPI;
+import minetweaker.api.item.IIngredient;
+import minetweaker.api.item.IItemStack;
+import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+
+@ZenClass("mods.rotarycraft.Grinder")
+public class GrinderTweaker {
+	protected RecipesGrinder grinder = RecipesGrinder.getRecipes();
+	
+    @ZenMethod
+    public static void addRecipe(IIngredient input, IIngredient output) {
+		ItemStack out = MinetweakerHelper.getStack(output);
+		if (isValid(out)) {
+			MineTweakerAPI.apply(new AddRecipe(input, output));
+		} else {
+			throw new IllegalArgumentException("You cannot add alternate recipes for native RotaryCraft items!");
+		}
+    }
+	
+	@ZenMethod
+    public static void addSeed(IIngredient input, double factor) {
+		MineTweakerAPI.apply(new AddSeed(input, (float)factor));
+    }
+	
+	private static boolean isValid(ItemStack out) {
+		return !out.getItem().getClass().getName().startsWith("Reika.RotaryCraft.Items");
+	}
+
+    private static class AddRecipe implements IUndoableAction {
+        private List<ItemStack> inputs = new ArrayList<ItemStack>;
+		private ItemStack output;
+
+        public AddRecipe(IIngredient input, IIngredient output) {
+            List<ItemStack> toAddRecipe = MinetweakerHelper.getStacks(input);
+			
+			for (ItemStack in : toAddRecipe) {
+				if (!grinder.isGrindable(in)) {
+					inputs.add(in);
+				}
+			}
+        }
+
+        @Override
+        public void apply() {
+            for (ItemStack in : inputs) {
+				grinder.addExtraRecipe(in, output);
+			}
+        }
+
+        @Override
+        public boolean canUndo() {
+            return true;
+        }
+
+        @Override
+        public void undo() {
+            for (ItemStack in : inputs) {
+				grinder.removeExtraRecipe(in);
+			}
+        }
+
+        @Override
+        public String describe() {
+            return "Adding " + inputs.size() + " recipe" + (inputs.size() > 1 ? "s" : "") + " to Grinder for " + output.getDisplayName();
+        }
+
+        @Override
+        public String describeUndo() {
+            return "Removing " + inputs.size() + " recipe" + (inputs.size() > 1 ? "s" : "") + " to Grinder for " + output.getDisplayName();
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
+    }
+	
+	private static class AddSeed implements IUndoableAction {
+        private List<ItemStack> seeds = new ArrayList<ItemStack>;
+		private float factor;
+
+        public AddSeed(IIngredient input, float factor) {
+            List<ItemStack> toAddSeed = MinetweakerHelper.getStacks(input);
+			for (ItemStack in : toAddSeed) {
+				if (!TileEntityGrinder.isGrindableSeed(in)) {
+					seeds.add(in);
+				}
+			}
+        }
+
+        @Override
+        public void apply() {
+            for (ItemStack in : seeds) {
+				TileEntityGrinder.addGrindableSeed(in, factor);
+			}
+        }
+
+        @Override
+        public boolean canUndo() {
+            return true;
+        }
+
+        @Override
+        public void undo() {
+            for (ItemStack in : seeds) {
+				TileEntityGrinder.removeGrindableSeed(in);
+			}
+        }
+
+        @Override
+        public String describe() {
+            return "Adding " + seeds.size() + " seed" + (seeds.size() > 1 ? "s" : "") + " to Grinder";
+        }
+
+        @Override
+        public String describeUndo() {
+            return "Removing " + seeds.size() + " seed" + (seeds.size() > 1 ? "s" : "") + " to Grinder";
+        }
+
+        @Override
+        public Object getOverrideKey() {
+            return null;
+        }
+    }
+}

--- a/ModInterface/Minetweaker/MinetweakerHelper.java
+++ b/ModInterface/Minetweaker/MinetweakerHelper.java
@@ -1,0 +1,45 @@
+package RotaryCraft.ModInterface.Minetweaker;
+
+import static minetweaker.api.minecraft.MineTweakerMC.getItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import minetweaker.api.item.IIngredient;
+import minetweaker.api.item.IItemStack;
+import minetweaker.api.oredict.IOreDictEntry;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class MinetweakerHelper {
+    
+	public static ItemStack toStack(IItemStack iStack) {
+        return getItemStack(iStack);
+    }
+	
+	public static ItemStack getStack(IIngredient ingredient) {
+		if (ingredient == null) return null;
+        if (ingredient instanceof IOreDictEntry) {
+            return OreDictionary.getOres(toString((IOreDictEntry) ingredient)).get(0);
+        } else if (ingredient instanceof IItemStack) {
+            return getItemStack((IItemStack) ingredient);
+        }
+	}
+
+    public static List<ItemStack> getStacks(IIngredient ingredient)
+    {
+        if (ingredient == null) return null;
+        if (ingredient instanceof IOreDictEntry) {
+            return OreDictionary.getOres(toString((IOreDictEntry) ingredient));
+        } else if (ingredient instanceof IItemStack) {
+            ArrayList<ItemStack> result = new ArrayList<ItemStack>();
+            result.add(getItemStack((IItemStack)ingredient));
+			return result;
+        }
+        return null;
+    }
+
+    public static String toString(IOreDictEntry entry) {
+        return ((IOreDictEntry) entry).getName();
+    }
+}

--- a/TileEntities/Processing/TileEntityGrinder.java
+++ b/TileEntities/Processing/TileEntityGrinder.java
@@ -52,14 +52,23 @@ ConditionalOperation, DamagingContact {
 	private HybridTank tank = new HybridTank("grinder", MAXLUBE);
 
 	private static final ItemHashMap<Float> grindableSeeds = new ItemHashMap();
+	private static final List<ItemStack> protectedEntries = new ArrayList<ItemStack>();
 
 	static {
 		addGrindableSeed(ItemRegistry.CANOLA.getStackOf(), 1F);
+		protectedEntries.add(ItemRegistry.CANOLA.getStackOf());
 		//addGrindableSeed(ItemRegistry.CANOLA.getStackOfMetadata(2), 0.65F);
 	}
 
 	public static void addGrindableSeed(ItemStack seed, float factor) {
 		grindableSeeds.put(seed, MathHelper.clamp_float(factor, 0, 1));
+	}
+	
+	public static void removeGrindableSeed(ItemStack seed) {
+		for (ItemStack entry : protectedEntries) {
+			if (entry.isItemEqual(seed)) return;
+		}
+		grindableSeeds.remove(seed);
 	}
 
 	public static boolean isGrindableSeed(ItemStack seed) {


### PR DESCRIPTION
Added Minetweaker support for both Grinding recipes and seeds.

Recipes are stored in a different, editable HashMap, updated the relevant methods in RecipesGrinder
Checks for invalid output using the criteria defined in the Grinder API class, also checks for pre-existing recipe for that input. Input and output can be defined as either an OreDictionary entry (in which case it will add recipes for every entry that doesn't already exist for input, or the first OreDictionary entry for the output) or a specific ItemStack.

Seeds are added similarly to the seeds Map - but to protect against Canola being removed from the grinder a list of protected seeds is added - any seed on that list cannot be removed from the grindableSeed Map with the new removeGrindableSeed method

MinetweakerHelper class added to aid in MT input->ItemStacks. You might want to move this to DragonAPI at some point

Note: I had to write this outside of a dev environment - so it's very possible there are a couple of typos or missed imports you will have to clean up

Also didn't do any of the registering of the ZenClass (`MineTweakerAPI.registerClass(GrinderTweaker.class);`) as I imagine this is something you'd want to centralise through DragonAPI - eg. a static function that you pass the classes to, checks MT is loaded, then does the registering if required.
