### PR TITLE
Fixing Liquid Spiller behavior

### DIFF
--- a/TileEntities/World/TileEntityFlooder.java
+++ b/TileEntities/World/TileEntityFlooder.java
@@ -68,8 +68,8 @@ public class TileEntityFlooder extends RotaryCraftTileEntity implements IFluidHa
 			if (blocks.isEmpty()) {
 				int r = ConfigRegistry.SPILLERRANGE.getValue();
 				if (r > 0) {
-					blocks.recursiveAddWithBounds(world, x, y-1, z, Blocks.air, x-r, 0, z-r, x+r, y-1, z+r);
-					blocks.recursiveAddWithBoundsNoFluidSource(world, x, y-1, z, this.getFluidID(), x-r, 0, z-r, x+r, y-1, z+r);
+					blocks.recursiveAddWithBounds(world, x, y-1, z, Blocks.air, x-r, 0, z-r, x+r, y, z+r);
+					blocks.recursiveAddWithBoundsNoFluidSource(world, x, y-1, z, this.getFluidID(), x-r, 0, z-r, x+r, y, z+r);
 				}
 				blocks.sortBlocksByHeight();
 			}

--- a/TileEntities/World/TileEntityFlooder.java
+++ b/TileEntities/World/TileEntityFlooder.java
@@ -68,8 +68,8 @@ public class TileEntityFlooder extends RotaryCraftTileEntity implements IFluidHa
 			if (blocks.isEmpty()) {
 				int r = ConfigRegistry.SPILLERRANGE.getValue();
 				if (r > 0) {
-					blocks.recursiveAddWithBounds(world, x, y-1, z, Blocks.air, x-r, 0, z-r, x+r, y, z+r);
-					blocks.recursiveAddWithBoundsNoFluidSource(world, x, y-1, z, this.getFluidID(), x-r, 0, z-r, x+r, y, z+r);
+					blocks.recursiveAddWithBounds(world, x, y-1, z, Blocks.air, x-r, 0, z-r, x+r, y-1, z+r);
+					blocks.recursiveAddWithBoundsNoFluidSource(world, x, y-1, z, this.getFluidID(), x-r, 0, z-r, x+r, y-1, z+r);
 				}
 				blocks.sortBlocksByHeight();
 			}
@@ -86,9 +86,6 @@ public class TileEntityFlooder extends RotaryCraftTileEntity implements IFluidHa
 				world.markBlockForUpdate(c.xCoord, c.yCoord, c.zCoord);
 				tank.drain(1000, true);
 			}
-		}
-		else {
-			blocks.clear();
 		}
 	}
 


### PR DESCRIPTION
Currently problem is that liquid spiller doesn't fill full layer on y-1 (I suppose it's problem, but if it's intended then just ignore that), only block directly below it is filled, it's due to recursive function having less comparison on y coordinate so it won't grow recursion tree on last layer below spiller.