### PR TITLE
fix: Bevel GUI crash when ChromatiCraft is not installed

### DIFF
--- a/Registry/MachineRegistry.java
+++ b/Registry/MachineRegistry.java
@@ -27,7 +27,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
-import Reika.ChromatiCraft.Auxiliary.Interfaces.NBTTile;
 import Reika.DragonAPI.DragonAPICore;
 import Reika.DragonAPI.DragonOptions;
 import Reika.DragonAPI.ModList;
@@ -39,6 +38,7 @@ import Reika.DragonAPI.Instantiable.Data.Maps.MultiMap;
 import Reika.DragonAPI.Interfaces.Registry.TileEnum;
 import Reika.DragonAPI.Libraries.Java.ReikaJavaLibrary;
 import Reika.DragonAPI.Libraries.Registry.ReikaItemHelper;
+import Reika.DragonAPI.Libraries.ReikaNBTHelper;
 import Reika.DragonAPI.ModRegistry.PowerTypes;
 import Reika.RotaryCraft.RotaryCraft;
 import Reika.RotaryCraft.RotaryNames;
@@ -999,10 +999,14 @@ public enum MachineRegistry implements TileEnum {
 		if (this == GEARBOX) {
 			is = ((TileEntityGearbox)te).getGearboxType().getGearboxItem(((TileEntityGearbox)te).getRatio());
 		}
-		if (te instanceof NBTTile) {
-			if (is.stackTagCompound == null)
-				is.stackTagCompound = new NBTTagCompound();
-			((NBTTile)te).getTagsToWriteToStack(is.stackTagCompound);
+		if (te instanceof NBTMachine) {
+			NBTTagCompound nbt = ((NBTMachine)te).getTagsToWriteToStack();
+			if (nbt != null && !nbt.hasNoTags()) {
+				if (is.stackTagCompound == null)
+					is.stackTagCompound = (NBTTagCompound)nbt.copy();
+				else
+					ReikaNBTHelper.combineNBT(is.stackTagCompound, nbt);
+			}
 		}
 		return is;
 	}


### PR DESCRIPTION
## Summary
- `MachineRegistry.getCraftedProduct` referenced ChromatiCraft's `NBTTile`, so opening Bevel Gear GUI crashed with `NoClassDefFoundError` when ChromatiCraft was absent.
- Switch to RotaryCraft's `NBTMachine` and write item NBT via `getTagsToWriteToStack()` + `ReikaNBTHelper.combineNBT`.

## Error (before)
`Reported exception thrown! net.minecraft.util.ReportedException: Rendering screen at net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1092) at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1001) at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:898) at net.minecraft.client.main.Main.main(SourceFile:148) at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at java.lang.reflect.Method.invoke(Method.java:498) at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) at net.minecraft.launchwrapper.Launch.main(Launch.java:28) Caused by: java.lang.NoClassDefFoundError: Reika/ChromatiCraft/Auxiliary/Interfaces/NBTTile at Reika.RotaryCraft.Registry.MachineRegistry.getCraftedProduct(MachineRegistry.java:1002) at Reika.DragonAPI.Libraries.Rendering.ReikaRenderHelper.getBlockItem(ReikaRenderHelper.java:1931) at Reika.RotaryCraft.GUIs.Machine.GuiBevel.func_146979_b(GuiBevel.java:183) at net.minecraft.client.gui.inventory.GuiContainer.func_73863_a(GuiContainer.java:119) at net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1061) ... 9 more Caused by: java.lang.ClassNotFoundException: Reika.ChromatiCraft.Auxiliary.Interfaces.NBTTile at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:191) at java.lang.ClassLoader.loadClass(ClassLoader.java:418) at java.lang.ClassLoader.loadClass(ClassLoader.java:351) ... 14 more Caused by: java.lang.NullPointerException 20:24:00.478`

## Commit
- `a3481a7b` — fix: Bevel GUI NPE from missing ChromatiCraft NBTTile
